### PR TITLE
Alternative to huge switch/case

### DIFF
--- a/Weather/WeatherAppScreen.swift
+++ b/Weather/WeatherAppScreen.swift
@@ -8,10 +8,46 @@
 
 import Domain
 import Navigation
+import SwiftUI
+import Screens
 
-enum WeatherAppScreen: NavigationScreen {
-    case home
-    case locationWeather(location: LocationQuery)
-    case search
-    case settings
+struct WeatherAppScreen: NavigationScreen {
+    static func == (lhs: WeatherAppScreen, rhs: WeatherAppScreen) -> Bool {
+        lhs.title == rhs.title
+    }
+
+    let title: String
+    let view: (NavigationCoordinator<WeatherAppScreen>) -> any View
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+    }}
+
+extension WeatherAppScreen {
+    static let home = WeatherAppScreen(title: "home", view: { _ in HomeScreen() })
+}
+
+extension WeatherAppScreen {
+    static func locationWeather(location: LocationQuery) -> WeatherAppScreen {
+        WeatherAppScreen(title: "locationWeather", view: { _ in
+            LocationWeatherScreen(
+                location: location)
+        })
+    }
+}
+
+extension WeatherAppScreen {
+    static let search = WeatherAppScreen(title: "search", view: { coordinator in
+        FavoriteScreen { [weak coordinator] navigationRequest in
+            switch navigationRequest {
+            case .viewLocation(let location):
+                coordinator?.navigate(to: Navigation(
+                    screen: .locationWeather(location: location)))
+            }
+        }
+    })
+}
+
+extension WeatherAppScreen {
+    static let settings = WeatherAppScreen(title: "settings", view: { _ in SettingsScreen() })
 }

--- a/Weather/WeatherAppScreen.swift
+++ b/Weather/WeatherAppScreen.swift
@@ -21,7 +21,8 @@ struct WeatherAppScreen: NavigationScreen {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(title)
-    }}
+    }
+}
 
 extension WeatherAppScreen {
     static let home = WeatherAppScreen(title: "home", view: { _ in HomeScreen() })

--- a/Weather/WeatherAppScreenView.swift
+++ b/Weather/WeatherAppScreenView.swift
@@ -16,22 +16,6 @@ struct ApplicationRouterView: View {
     unowned let coordinator: NavigationCoordinator<WeatherAppScreen>
     
     var body: some View {
-        switch navigation.screen {
-        case .home:
-            HomeScreen()
-        case .locationWeather(let location):
-            LocationWeatherScreen(
-                location: location)
-        case .search:
-            FavoriteScreen { [weak coordinator] navigationRequest in
-                switch navigationRequest {
-                case .viewLocation(let location):
-                    coordinator?.navigate(to: Navigation(
-                        screen: .locationWeather(location: location)))
-                }
-            }
-        case .settings:
-            SettingsScreen()
-        }
+        return AnyView(navigation.screen.view(coordinator))
     }
 }


### PR DESCRIPTION
The idea here is that because `WeatherAppScreen` is a struct rather than an enum. New screens can be added using extensions to the type and there is no need for a switch in the ApplicationRouterView. When dealing with possibly 100 screens, I think that large of an enum is begging for merge problems.

Although I put all the extensions in the same file, they could be moved elsewhere in the code base which will reduce merge conflicts. Notice that I didn't have to change the way the Screens themselves are implemented. The `FavoriteScreen` is still unaware of exactly how the navigation to the location weather screen is happening.

I think this sort of change better comports with the Open-Closed principle (adding a new screen does not require breaking open any existing files or modifying any existing types.) I think it also does a better job of conforming to the Single Responsibility principle. (We have individual methods each responsible for creating individual screens instead of a single method responsible for creating every possible view.)

Downsides include the use of AnyView which I know you don't particularly like. Also, the fact that `NavigationScreen` is Hashable made for some weirdness (does it really have to be Hashable?)